### PR TITLE
Wait for dpkg lock

### DIFF
--- a/libmachine/provision/ubuntu_systemd.go
+++ b/libmachine/provision/ubuntu_systemd.go
@@ -76,7 +76,7 @@ func (provisioner *UbuntuSystemdProvisioner) Package(name string, action pkgacti
 		}
 	}
 
-	command := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive sudo -E apt-get %s -y  %s", packageAction, name)
+	command := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive sudo -E apt-get -o DPkg::Lock::Timeout=300  %s -y  %s", packageAction, name)
 
 	log.Debugf("package: action=%s name=%s", action.String(), name)
 


### PR DESCRIPTION
Make Ubuntu systemd provisioner a little more robust by waiting on the dpkg lock for 5 minutes max. This is useful in environments where packages are installed in the backgroud automatically (Azure) which prevent docker-machine from provisioning successfully. 